### PR TITLE
fmrinoise script: /bin/sh instead of /usr/bin/sh

### DIFF
--- a/fmridenoise/scripts/fmridenoise
+++ b/fmridenoise/scripts/fmridenoise
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 if command -v "python3" > /dev/null
 then
     python3 -O -m fmridenoise "$@"


### PR DESCRIPTION
- Change the #! of the fmridenoise script to /bin/sh
- I was just supporting a user who was running on an OS without
  /usr/bin/sh, a university machine that doesn't yet link /bin/ to
  /usr/bin.
- I think that /bin/sh should be the canonical location according to
  the relevant standards, and this should also work on newer systems
  where /bin is linked to /usr/bin.
- My other idea was `/usr/bin/env sh` but that seems like needless
  indirection.

To review:
- Is this package used on any other weird platforms that I don't know about, or other reasons why /usr/bin is needed?
